### PR TITLE
Editorial fix: Rename [coroutine.handle.import.export] to [coroutine.handle.export.import] to be consistent with the section header and the order in which definitions appear

### DIFF
--- a/Coroutines/support.tex
+++ b/Coroutines/support.tex
@@ -197,7 +197,7 @@ inline namespace coroutines_v1 {
     static coroutine_handle from_promise(Promise&);		
     coroutine_handle& operator=(nullptr_t) noexcept;
 
-    // \ref{coroutine.handle.import} import
+    // \ref{coroutine.handle.import.export} import
     constexpr static coroutine_handle from_address(void* addr);
     
     // \ref{coroutine.handle.promise} promise access
@@ -259,21 +259,6 @@ A default constructed \tcode{coroutine_handle} object does not refer to any coro
 	\pnum
 	\returns \tcode{ptr}.
 \end{itemdescr}
-
-
-\begin{itemdecl}
-  static coroutine_handle coroutine_handle<>::from_address(void* addr);		
-\end{itemdecl}
-
-\begin{itemdescr}
-	\pnum
-	\precondition \tcode{addr} was obtained via a prior call to \tcode{address()}.
-	
-	\pnum
-	\postconditions \tcode{from_address(address()) == *this}.
-\end{itemdescr}
-
-\rSec3[coroutine.handle.import]{\tcode{coroutine_handle} import}
 
 \begin{itemdecl}
   static coroutine_handle from_address(void* addr);

--- a/Coroutines/support.tex
+++ b/Coroutines/support.tex
@@ -261,7 +261,8 @@ A default constructed \tcode{coroutine_handle} object does not refer to any coro
 \end{itemdescr}
 
 \begin{itemdecl}
-  constexpr static coroutine_handle from_address(void* addr);
+  constexpr static coroutine_handle<> coroutine_handle<>::from_address(void* addr);
+  constexpr static coroutine_handle<Promise> coroutine_handle<Promise>::from_address(void* addr);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/Coroutines/support.tex
+++ b/Coroutines/support.tex
@@ -172,7 +172,7 @@ inline namespace coroutines_v1 {
     constexpr coroutine_handle(nullptr_t) noexcept;
     coroutine_handle& operator=(nullptr_t) noexcept;
     
-    // \ref{coroutine.handle.import.export} export/import
+    // \ref{coroutine.handle.export.import} export/import
     constexpr void* address() const noexcept;
     constexpr static coroutine_handle from_address(void* addr);
     
@@ -197,7 +197,7 @@ inline namespace coroutines_v1 {
     static coroutine_handle from_promise(Promise&);		
     coroutine_handle& operator=(nullptr_t) noexcept;
 
-    // \ref{coroutine.handle.import.export} import
+    // \ref{coroutine.handle.export.import} import
     constexpr static coroutine_handle from_address(void* addr);
     
     // \ref{coroutine.handle.promise} promise access
@@ -249,7 +249,7 @@ A default constructed \tcode{coroutine_handle} object does not refer to any coro
   \pnum\returns \tcode{*this}.
 \end{itemdescr}
 
-\rSec3[coroutine.handle.import.export]{\tcode{coroutine_handle} export/import}
+\rSec3[coroutine.handle.export.import]{\tcode{coroutine_handle} export/import}
 
 \begin{itemdecl}
   constexpr void* address() const noexcept;

--- a/Coroutines/support.tex
+++ b/Coroutines/support.tex
@@ -261,7 +261,7 @@ A default constructed \tcode{coroutine_handle} object does not refer to any coro
 \end{itemdescr}
 
 \begin{itemdecl}
-  static coroutine_handle from_address(void* addr);
+  constexpr static coroutine_handle from_address(void* addr);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/Coroutines/support.tex
+++ b/Coroutines/support.tex
@@ -266,7 +266,7 @@ A default constructed \tcode{coroutine_handle} object does not refer to any coro
 
 \begin{itemdescr}
  \pnum
- \precondition \tcode{addr} was obtained via a prior call to \tcode{address()}.
+ \precondition \tcode{addr} was obtained via a prior call to \tcode{address}.
 
  \pnum
  \postconditions \tcode{from_address(address()) == *this}.


### PR DESCRIPTION
**Note that this PR is rebased against #4, so I'd review that one first**

In the class synopsis for `coroutine_handle<>` in [**coroutine.handle**], this section is referred to as "export/import", and the export function (`address`) is listed before the import function (`from_address`). Likewise, in the definitions for these two methods in [**coroutine.handle.import.export**], the section is titled "Export/import" and `address` appears first. Since `from_address` mentions `address`, this seems like the correct order to list things in as it avoids adding forward references to the spec.

I'd like to rename this stable tag from [**coroutine.handle.import.export**] to [**coroutine.handle.export.import**] [as an editorial change before PTDS.